### PR TITLE
chore: removes 'unique' field from savedRecipes to save more than 1 user in db

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -22,7 +22,7 @@ const UserSchema = new Schema(
     savedRecipes: [
       {
         type: Schema.Types.ObjectId,
-        unique: true
+        ref: 'Recipe'
       }
     ],
     tokens: [


### PR DESCRIPTION
The ```unique``` flag on the ```savedRecipes``` field on the ```User``` model caused Mongo to only allow for 1 user to be saved at a time since an index was created for the ```savedRecipe``` field when exactly one user was created. Anytime after a user was created, Mongo would register that a ```savedRecipe``` field was already in place via ```unique``` field and therefore would not allow saving for another user. This PR aims to fix that by removing the ```unique``` flag while referencing the correct db model. 

## Important Notes

Additionally, you may need to run the following command in the db in order for this to work as Mongo will still retain that index even after the code is updated:

```db.users.dropIndex('savedRecipes_1');```

## Testing

If you are only able to save 1 user in the database, pull in this code, then run the following command in MongoDB via Robo3T, Mongo Compass, or the terminal:


I used Robo3T to accomplish it, but you may use Mongo Compass or terminal to achieve the same thing. 

![Screen Shot 2022-08-06 at 11 37 34 AM](https://user-images.githubusercontent.com/55468908/183261838-881f1e46-aec3-47e9-aa8b-80dc01c43abc.png)

